### PR TITLE
Fix PythonREPL and requirements

### DIFF
--- a/llm_agents/tools/python_repl.py
+++ b/llm_agents/tools/python_repl.py
@@ -1,4 +1,5 @@
 import sys
+import re
 from io import StringIO
 from typing import Dict, Optional
 
@@ -44,7 +45,7 @@ class PythonREPLTool(ToolInterface):
     python_repl: PythonREPL = Field(default_factory=_get_default_python_repl)
 
     def use(self, input_text: str) -> str:
-        input_text = input_text.strip().strip("```")
+        input_text = re.sub(r'^.*[`]{3}.*\n?', '', input_text, flags=re.MULTILINE)
         return self.python_repl.run(input_text)
 
 


### PR DESCRIPTION
In PythonREPL, many lines now begin with triple quotes, eg
''' Python

Original code removed the triple quotes, but the word "Python" is left there which doesn't work in the self.python_repl.run(input_textZ) command.  The new code removes any line containing triple quotes.

Also added beautifulsoup4 in requirements.txt and fixed the version of openai to 0.28.0 which is needed to make the package work